### PR TITLE
Fix: prevent the `submission` tab from showing up before freelancer's signing a project

### DIFF
--- a/frontend/components/projectDetails/ProjectDetails.tsx
+++ b/frontend/components/projectDetails/ProjectDetails.tsx
@@ -379,7 +379,8 @@ const ProjectDetails = ({ projectId }: { projectId: string }): JSX.Element => {
                   type={"button"}
                 />
                 {projectDetails.Status !== StatusEnum.CompleteNoSubmissionByLancer
-                && projectDetails.Status !== StatusEnum.PayInAdvance && (
+                && projectDetails.Status !== StatusEnum.PayInAdvance 
+                && projectDetails.Status !== StatusEnum.WaitingForConnectingLancersWallet && (
                   <CustomButton
                     text="Submission"
                     styles={`${


### PR DESCRIPTION
# Description

- Add: `projectDetails.Status !== StatusEnum.WaitingForConnectingLancersWallet`

Close #217 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 
