### PR TITLE
Improvement: change the notification sentence for deadline-extension …

### DIFF
--- a/frontend/components/projectDetails/ProjectDetailsDescription.tsx
+++ b/frontend/components/projectDetails/ProjectDetailsDescription.tsx
@@ -192,7 +192,7 @@ const ProjectDetailsDescription = ({
   const acceptDeadlineExtension = async () => {
     try {
       if (projectDetails["Lancer's Wallet Address"] !== freelancerAddress) {
-        throw new Error("Not authorized to either accept or reject the deadline-extension");
+        throw new Error("This action can be taken by the freelancer. Wait until being accepted");
       }
 
       const submissionDeadline = new Date(projectDetails["Deadline(UTC)"]);
@@ -224,11 +224,11 @@ const ProjectDetailsDescription = ({
       });
       setShowNotification(true);
     } catch (error) {
-      console.log(error);
+      console.log(error.message);
       setNotificationConfiguration({
         modalColor: "#d14040",
         title: "Error",
-        message: "Not authorized to either accept or reject the deadline-extension",
+        message: error.message,
         icon: IconNotificationError,
       });
     }
@@ -238,7 +238,7 @@ const ProjectDetailsDescription = ({
   const rejectDeadlineExtension = async () => {
     try {
       if (projectDetails["Lancer's Wallet Address"] !== freelancerAddress) {
-        throw new Error("Not authorized to either accept or reject the deadline-extension");
+        throw new Error("This action can be taken by the freelancer. Wait until being accepted");
       }
 
       const paymentDeadline = new Date(projectDetails["Deadline(UTC) For Payment"]);
@@ -267,11 +267,11 @@ const ProjectDetailsDescription = ({
       });
       setShowNotification(true);
     } catch (error) {
-      console.log(error);
+      console.log(error.message);
       setNotificationConfiguration({
         modalColor: "#d14040",
         title: "Error",
-        message: "Not authorized to either accept or reject the deadline-extension",
+        message: error.message,
         icon: IconNotificationError,
       });
     }


### PR DESCRIPTION
# Description

- Old: `Not authorized to either accept or reject the deadline-extension`
- New: `This action can be taken by the freelancer. Wait until being accepted`

Close #239 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

<img width="1601" alt="Screen Shot 2023-10-04 at 15 57 55" src="https://github.com/Succery-dev/Qube/assets/54393289/900c2ec0-bda1-4ec5-93d9-605cbcb58ce1">
