### PR TITLE
Fix: can't scroll and save the onboarding info because of overflow

### DIFF
--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -354,7 +354,7 @@ const Navbar = (): JSX.Element => {
             className="fixed w-screen h-screen top-0 left-0 backdrop-blur-md z-[100] grid grid-cols-12 text-white font-nunito"
           >
             <div className="col-start-2 col-end-12 xl:col-start-4 xl:col-end-10 grid place-items-center">
-              <div className="w-full border border-[#E220CF] shadow-custom-pink rounded-xl p-[2px] flex flex-row items-center">
+              <div className="w-full border border-[#E220CF] shadow-custom-pink rounded-xl p-[2px] flex flex-row items-center overflow-y-auto">
                 <div className="w-full max-h-[95vh] bg-black rounded-xl px-4 py-6 sm:p-8 md:p-10 lg:p-8 xl:p-10 relative">
                   {/* Header */}
                   <div className="flex flex-row w-full justify-between items-center top-0 right-0 z-[100]">


### PR DESCRIPTION
# Description

- Add: `overflow-y-auto`

Close #422 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 
